### PR TITLE
Speedup Sagecal

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -370,7 +370,7 @@ EOF
 	cd $INSTALLDIR/sagecal
 	git clone https://github.com/nlesc-dirac/sagecal.git src
 	cd build
-	cmake -DOpenBLAS_LIB=/opt/OpenBLAS/lib64/libopenblas.so -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/sagecal -DLIB_ONLY=True ../src
+	cmake -DOpenBLAS_LIB=/opt/OpenBLAS/lib64/libopenblas.so -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/sagecal -DLIB_ONLY=True -Wno-dev -DCMAKE_CXX_FLAGS='-g -O3 -fopenmp -ffast-math -lmvec -lm' -DCMAKE_C_FLAGS='-g -O3 -fopenmp -ffast-math -lmvec -lm' ../src
 	make -j $j
 	make install
 	rm -rf $INSTALLDIR/sagecal/build


### PR DESCRIPTION
Just want to show you - I think this was officially supported some time ago. I dont know how it is now. These are my installation notes from ~1 year ago:

cmake .. -DLIB_ONLY=1 -Wno-dev -DCMAKE_CXX_FLAGS='-g -O3 -fopenmp -ffast-math -lmvec -lm -march=native -mtune=native' -DCMAKE_C_FLAGS='-g -O3 -fopenmp -ffast-math -lmvec -lm -march=native -mtune=native'