### PR TITLE
Update DS9

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -531,7 +531,7 @@ From: fedora:40
     #
     mkdir -p $INSTALLDIR/ds9/bin
     cd $INSTALLDIR/ds9
-    wget http://ds9.si.edu/download/fedora36x86/ds9.fedora36x86.8.5.tar.gz
+    wget https://ds9.si.edu/download/fedora38x86/ds9.fedora38x86.8.6.tar.gz
     tar xf ds9*.tar.gz -C $INSTALLDIR/ds9/bin
     rm ds9*.tar.gz
 

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -462,7 +462,7 @@ EOF
     #
     mkdir -p $INSTALLDIR/ds9/bin
     cd $INSTALLDIR/ds9
-    wget http://ds9.si.edu/download/fedora36x86/ds9.fedora36x86.8.5.tar.gz
+    wget https://ds9.si.edu/download/fedora38x86/ds9.fedora38x86.8.6.tar.gz
     tar xf ds9*.tar.gz -C $INSTALLDIR/ds9/bin
     rm ds9*.tar.gz
 


### PR DESCRIPTION
Closer to the final Fedora version, no matter which one it will be. Previous version was for Fedora 36. Also this enables download from http**s**.