### PR TITLE
Fix deprecation

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -244,7 +244,7 @@ From: fedora:39
     tar xf lofar_lta-*
     cd lofar_lta-2.8.0
     #python setup.py install_oracle
-    python setup.py install
+    pip install .
     cd ..
     rm lofar_lta*.tar.gz
     rm -rf lofar_lta-2.8.0/

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -222,7 +222,7 @@ EOF
     tar xf lofar_lta-*
     cd lofar_lta-2.8.0
     #python setup.py install_oracle
-    python setup.py install
+    pip install .
     cd ..
     rm lofar_lta*.tar.gz
     rm -rf lofar_lta-2.8.0/


### PR DESCRIPTION
Installing via setup.py is deprecated and there were complains in the log about this.