### PR TITLE
Add CASACORE_ROOT_DIR var

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -326,6 +326,7 @@ From: fedora:39
     cd $INSTALLDIR
     rm -rf $INSTALLDIR/casacore/build
     rm -rf $INSTALLDIR/casacore/src
+    export CASACORE_ROOT_DIR=$INSTALLDIR/casacore
 
     #
     # Install Python-CASAcore
@@ -747,6 +748,7 @@ From: fedora:39
 
     echo "measures.directory: $INSTALLDIR/casacore/data" > $INSTALLDIR/.casarc 
     echo export CASARCFILES=\$INSTALLDIR/.casarc >> $INSTALLDIR/init.sh
+    echo export CASACORE_ROOT_DIR=\$INSTALLDIR/casacore >> $INSTALLDIR/init.sh
 
     echo "# DDF environment settings" >> $INSTALLDIR/init.sh
     echo export DDF_DIR=$INSTALLDIR >> $INSTALLDIR/init.sh

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -296,6 +296,7 @@ EOF
     cd $INSTALLDIR
     rm -rf $INSTALLDIR/casacore/build
     rm -rf $INSTALLDIR/casacore/src
+    export CASACORE_ROOT_DIR=$INSTALLDIR/casacore
 
     #
     # Install Python-CASAcore
@@ -699,6 +700,7 @@ EOF
 
     echo "measures.directory: $INSTALLDIR/casacore/data" > $INSTALLDIR/.casarc 
     echo export CASARCFILES=\$INSTALLDIR/.casarc >> $INSTALLDIR/init.sh
+    echo export CASACORE_ROOT_DIR=\$INSTALLDIR/casacore >> $INSTALLDIR/init.sh
     echo export LD_LIBRARY_PATH=/opt/intel/oneapi/mkl/latest/lib/intel64/:/opt/intel/oneapi/compiler/latest/lib/:/opt/intel/oneapi/tbb/latest/env/../lib/intel64/gcc4.8:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
 
 


### PR DESCRIPTION
Sagecal uses this and its working:

> Using environment variable CASACORE_ROOT_DIR = /opt/lofar/casacore