### PR TITLE
 AMD  - Fix C FLAGS for CASACore

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -319,8 +319,8 @@ From: fedora:40
         -DFFTW3F_THREADS_LIBRARY="${AOCL_ROOT}/lib/libfftw3f_threads.so" \
         -DFFTW3_INCLUDE_DIR="${AOCL_ROOT}/include" \
         -DLAPACK_LIBRARIES="${AOCL_ROOT}/lib/libflame.so" \
-        -DCMAKE_CXX_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
-        -DCMAKE_C_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
+        -DCMAKE_CXX_FLAGS="${CXXFLAGS} -L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
+        -DCMAKE_C_FLAGS="${CFLAGS} -L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
         ../src/ 
     cd ${INSTALLDIR}/casacore/build && make -s -j ${J}
     cd ${INSTALLDIR}/casacore/build && make install


### PR DESCRIPTION
# Description

- fixed overwriting flags
- removed duplicated march, as it is passed in `CFLAGS` and `CXXFLAGS`