### PR TITLE
Remove wheel from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -127,5 +127,4 @@ traceback2
 unittest2
 uritemplate
 urllib3
-wheel
 unittest-xml-reporting


### PR DESCRIPTION
# Description
Remove `wheel` from `requirements.txt` as it is installed in the recipe before `pip install -r $INSTALLDIR/requirements.txt`.