### PR TITLE
Remove pymysql from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,6 @@ pyephem
 pyFFTW
 pylru
 pymultinest
-pymysql
 pyparsing
 pyregion
 pytest


### PR DESCRIPTION
# Description

Related to https://github.com/tikk3r/flocs/issues/159. After removing it does compile and there is no `pymysql` in the log.