### PR TITLE
Update PyBDSF and switch to manual build

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -30,7 +30,7 @@ From: fedora:40
     export IDG_VERSION=2af6f285
     export LOSOTO_VERSION=latest
     export OPENBLAS_VERSION=v0.3.28
-    export PYBDSF_VERSION=720f5c3
+    export PYBDSF_VERSION=8471637
     export PYTHON_CASACORE_VERSION=3.6.1
     export RMEXTRACT_VERSION=0.5.0
     export WSCLEAN_VERSION=443bd576
@@ -292,7 +292,7 @@ From: fedora:40
     mkdir -p ${INSTALLDIR}/pybdsf
     cd ${INSTALLDIR}/pybdsf && git clone https://github.com/lofar-astron/pybdsf && cd ${INSTALLDIR}/pybdsf/pybdsf && git checkout ${PYBDSF_VERSION} && echo export PYBDSF_VERSION=$(git rev-parse --short HEAD) >> $INSTALLDIR/init.sh
     cd ${INSTALLDIR}/pybdsf/pybdsf
-    pip install bdsf
+    pip install .
     cd $INSTALLDIR
     rm -rf $INSTALLDIR/pybdsf/pybdsf
 

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -32,7 +32,7 @@ From: fedora:40
     export LAPACK_VERSION=3.8.0
     export LOSOTO_VERSION=latest
     export OPENBLAS_VERSION=v0.3.28
-    export PYBDSF_VERSION=720f5c3
+    export PYBDSF_VERSION=8471637
     export PYTHON_CASACORE_VERSION=3.6.1
     export RMEXTRACT_VERSION=0.5.0
     export WSCLEAN_VERSION=443bd576
@@ -265,7 +265,7 @@ EOF
     mkdir -p ${INSTALLDIR}/pybdsf
     cd ${INSTALLDIR}/pybdsf && git clone https://github.com/lofar-astron/pybdsf && cd ${INSTALLDIR}/pybdsf/pybdsf && git checkout ${PYBDSF_VERSION} && echo export PYBDSF_VERSION=$(git rev-parse --short HEAD) >> $INSTALLDIR/init.sh
     cd ${INSTALLDIR}/pybdsf/pybdsf
-    pip install bdsf
+    pip install .
     cd $INSTALLDIR
     rm -rf $INSTALLDIR/pybdsf/pybdsf
 


### PR DESCRIPTION
# Description

Update PyBDSF to current master. It is now compatible with Python 3.12 and 3.13. Manual build can make it faster at runtime. Also allows passing optimization flags like `-march` in `FFLAGS`.
Related: https://github.com/tikk3r/flocs/issues/174.