### PR TITLE
Enable AOCL in Sagecal

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -361,6 +361,7 @@ From: fedora:40
     git clone https://github.com/nlesc-dirac/sagecal.git src
     cd build
     cmake $CMAKE_ADD_OPTION -DOpenBLAS_LIB=/opt/OpenBLAS/lib64/libopenblas.so \
+        -DBLA_VENDOR=AOCL_mt \
         -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/sagecal \
         -DLIB_ONLY=True \
         -DCMAKE_CXX_FLAGS='-g0' -DCMAKE_C_FLAGS='-g0' -DCMAKE_Fortran_FLAGS='-g0' \


### PR DESCRIPTION
# Description

Before:
```
-- Found BLAS: /usr/lib64/libflexiblas.so
-- Using BLAS: All
-- Looking for Fortran cheev
-- Looking for Fortran cheev - found
-- Found LAPACK: /usr/lib64/libflexiblas.so;-lm;-ldl

[...]

-- OpenBLAS_LIB .............. = /opt/OpenBLAS/lib64/libopenblas.so
-- GLIB_PKG_INCLUDE_DIRS...... = /usr/include/glib-2.0;/usr/lib64/glib-2.0/include;/usr/include/sysprof-6;/usr/include
-- GLIB_PKG_LIBRARIES......... = glib-2.0
-- LAPACK_LIBRARIES........... = /usr/lib64/libflexiblas.so;-lm;-ldl

[...]

BLAS_flexiblas_LIBRARY:FILEPATH=/usr/lib64/libflexiblas.so
```

After:
```
-- Found BLAS: /opt/aocl/4.0/lib/libblis-mt.so
-- Using BLAS: AOCL_mt
-- Looking for Fortran cheev
-- Looking for Fortran cheev - found
-- Found LAPACK: /opt/aocl/4.0/lib/libflame.so;/opt/aocl/4.0/lib/libblis-mt.so;-fopenmp

[...]

-- OpenBLAS_LIB .............. = /opt/OpenBLAS/lib64/libopenblas.so
-- GLIB_PKG_INCLUDE_DIRS...... = /usr/include/glib-2.0;/usr/lib64/glib-2.0/include;/usr/include/sysprof-6;/usr/include
-- GLIB_PKG_LIBRARIES......... = glib-2.0
-- LAPACK_LIBRARIES........... = /opt/aocl/4.0/lib/libflame.so;/opt/aocl/4.0/lib/libblis-mt.so;-fopenmp

[...]

BLAS_blis_mt_LIBRARY:FILEPATH=/opt/aocl/4.0/lib/libblis-mt.so
```