### PR TITLE
Add `flexiblas list` in the debud mode

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -199,6 +199,9 @@ From: fedora:40
     flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
     export FLEXIBLAS=OPENBLAS
     export FLEXIBLAS64=OPENBLAS
+    if [ $DEBUG = true ]; then
+        flexiblas list
+    fi
 
     # MultiNest
     cd $INSTALLDIR

--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -201,6 +201,7 @@ From: fedora:40
     export FLEXIBLAS64=OPENBLAS
     if [ $DEBUG = true ]; then
         flexiblas list
+        flexiblas print
     fi
 
     # MultiNest

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -168,6 +168,9 @@ EOF
     flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
     export FLEXIBLAS=OPENBLAS
     export FLEXIBLAS64=OPENBLAS
+    if [ $DEBUG = true ]; then
+        flexiblas list
+    fi
 
     # MultiNest
     cd $INSTALLDIR

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -170,6 +170,7 @@ EOF
     export FLEXIBLAS64=OPENBLAS
     if [ $DEBUG = true ]; then
         flexiblas list
+        flexiblas print
     fi
 
     # MultiNest


### PR DESCRIPTION
# Description

Add `flexiblas list` and `print` in the debug mode. Current output is:

```
+ flexiblas list
System-wide:
 OPENBLAS
   library = /opt/OpenBLAS/lib64/libopenblas.so
   comment = 
System-wide (config directory):
 OPENBLAS-SERIAL
   library = libflexiblas_openblas-serial.so
   comment = 
 NETLIB
   library = libflexiblas_netlib.so
   comment = 
 OPENBLAS-OPENMP
   library = libflexiblas_openblas-openmp.so
   comment = 
User config:
Host config:
Enviroment config:
+ flexiblas print
FlexiBLAS, version 3.4.4
Copyright (C) 2013-2024 Martin Koehler and others.
This is free software; see the source code for copying conditions.
There is ABSOLUTELY NO WARRANTY; not even for MERCHANTABILITY or
FITNESS FOR A PARTICULAR PURPOSE.


Configured BLAS libraries:
System-wide (/etc/flexiblasrc):
 OPENBLAS
   library = /opt/OpenBLAS/lib64/libopenblas.so
   comment = 

System-wide from config directory (/etc/flexiblasrc.d/)
 OPENBLAS-SERIAL
   library = libflexiblas_openblas-serial.so
   comment = 
 NETLIB
   library = libflexiblas_netlib.so
   comment = 
 OPENBLAS-OPENMP
   library = libflexiblas_openblas-openmp.so
   comment = 

User config (/root/.flexiblasrc):

Host config (/root/.flexiblasrc.lof8):

Available hooks:

Backend and hook search paths:
  /usr/lib64/flexiblas/

Default BLAS:
    System:       OPENBLAS-OPENMP
    User:         (none)
    Host:         (none)
    Active Default: OPENBLAS-OPENMP (System)
Run-time properties:
   verbose = 0 (System)
```