### PR TITLE
Upgrade OpenBLAS to v0.3.29

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -29,7 +29,7 @@ From: fedora:40
     export HDF5_VERSION=1.14.5
     export IDG_VERSION=2af6f285
     export LOSOTO_VERSION=latest
-    export OPENBLAS_VERSION=v0.3.28
+    export OPENBLAS_VERSION=v0.3.29
     export PYBDSF_VERSION=720f5c3
     export PYTHON_CASACORE_VERSION=3.6.1
     export RMEXTRACT_VERSION=0.5.0

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -31,7 +31,7 @@ From: fedora:40
     export IDG_VERSION=2af6f285
     export LAPACK_VERSION=3.8.0
     export LOSOTO_VERSION=latest
-    export OPENBLAS_VERSION=v0.3.28
+    export OPENBLAS_VERSION=v0.3.29
     export PYBDSF_VERSION=720f5c3
     export PYTHON_CASACORE_VERSION=3.6.1
     export RMEXTRACT_VERSION=0.5.0


### PR DESCRIPTION
# Description

Upgrade OpenBLAS to the latest version: https://github.com/OpenMathLib/OpenBLAS/releases/tag/v0.3.29. It has better support of gcc 14.