### PR TITLE
Direct linking to AOCL for DP3

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -459,13 +459,11 @@ From: fedora:40
     if [ $MARCH = 'x86-64' ] && [ $MTUNE = 'generic' ]; then
         cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLDIR/DP3 -DIDGAPI_LIBRARIES=$INSTALLDIR/idg/lib/libidg-api.so \
         -DIDGAPI_INCLUDE_DIRS=$INSTALLDIR/idg/include -DAOFLAGGER_INCLUDE_DIR=$INSTALLDIR/aoflagger/include -DAOFLAGGER_LIB=$INSTALLDIR/aoflagger/lib/libaoflagger.so \
-        -DPORTABLE=True -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ -DBLAS_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libblis.so -DLAPACK_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libflame.so \
-        ../src
+        -DPORTABLE=True -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ -DBLA_VENDOR=AOCL_mt ../src
     else
         cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLDIR/DP3 -DIDGAPI_LIBRARIES=$INSTALLDIR/idg/lib/libidg-api.so \
         -DIDGAPI_INCLUDE_DIRS=$INSTALLDIR/idg/include -DAOFLAGGER_INCLUDE_DIR=$INSTALLDIR/aoflagger/include -DAOFLAGGER_LIB=$INSTALLDIR/aoflagger/lib/libaoflagger.so \
-        -DTARGET_CPU=${MARCH} -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ \
-        -DBLAS_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libblis.so -DLAPACK_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libflame.so ../src
+        -DTARGET_CPU=${MARCH} -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ -DBLA_VENDOR=AOCL_mt ../src
     fi
     # Boost 1.75 requires c++14, so override this during make
     make -s -j $J && make install

--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -457,15 +457,15 @@ From: fedora:40
     echo export DP3_VERSION=$(git rev-parse --short HEAD) >> $INSTALLDIR/init.sh
     cd $INSTALLDIR/DP3/build
     if [ $MARCH = 'x86-64' ] && [ $MTUNE = 'generic' ]; then
-        cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLDIR/DP3 -DIDGAPI_LIBRARIES=$INSTALLDIR/idg/lib/libidg-api.so -DIDGAPI_INCLUDE_DIRS=$INSTALLDIR/idg/include -DAOFLAGGER_INCLUDE_DIR=$INSTALLDIR/aoflagger/include -DAOFLAGGER_LIB=$INSTALLDIR/aoflagger/lib/libaoflagger.so -DPORTABLE=True -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ \
-        -DBLAS_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libblis.so \
-        -DLAPACK_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libflame.so \
+        cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLDIR/DP3 -DIDGAPI_LIBRARIES=$INSTALLDIR/idg/lib/libidg-api.so \
+        -DIDGAPI_INCLUDE_DIRS=$INSTALLDIR/idg/include -DAOFLAGGER_INCLUDE_DIR=$INSTALLDIR/aoflagger/include -DAOFLAGGER_LIB=$INSTALLDIR/aoflagger/lib/libaoflagger.so \
+        -DPORTABLE=True -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ -DBLAS_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libblis.so -DLAPACK_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libflame.so \
         ../src
     else
-        cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLDIR/DP3 -DIDGAPI_LIBRARIES=$INSTALLDIR/idg/lib/libidg-api.so -DIDGAPI_INCLUDE_DIRS=$INSTALLDIR/idg/include -DAOFLAGGER_INCLUDE_DIR=$INSTALLDIR/aoflagger/include -DAOFLAGGER_LIB=$INSTALLDIR/aoflagger/lib/libaoflagger.so -DTARGET_CPU=${MARCH} -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ \
-        -DBLAS_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libblis.so \
-        -DLAPACK_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libflame.so \
-        ../src
+        cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX:PATH=$INSTALLDIR/DP3 -DIDGAPI_LIBRARIES=$INSTALLDIR/idg/lib/libidg-api.so \
+        -DIDGAPI_INCLUDE_DIRS=$INSTALLDIR/idg/include -DAOFLAGGER_INCLUDE_DIR=$INSTALLDIR/aoflagger/include -DAOFLAGGER_LIB=$INSTALLDIR/aoflagger/lib/libaoflagger.so \
+        -DTARGET_CPU=${MARCH} -DLIBDIRAC_PREFIX=$INSTALLDIR/sagecal/ \
+        -DBLAS_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libblis.so -DLAPACK_flexiblas_LIBRARY=${AOCL_ROOT}/lib/libflame.so ../src
     fi
     # Boost 1.75 requires c++14, so override this during make
     make -s -j $J && make install


### PR DESCRIPTION
# Description
This is to remove wrapper and link directly.

BEFORE:

> -- Found BLAS: /opt/aocl/4.0/lib/libblis.so
> [...]
> -- Found LAPACK: /opt/aocl/4.0/lib/libflame.so;/opt/aocl/4.0/lib/libblis.so

AFTER:

> -- Found BLAS: /opt/aocl/4.0/lib/libblis-mt.so
> [...]
> -- Found LAPACK: /opt/aocl/4.0/lib/libflame.so;/opt/aocl/4.0/lib/libblis-mt.so;-fopenmp

It does compile.