### PR TITLE
Make CUDA 12.6 compiler work on Fedora 40

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -196,6 +196,11 @@ From: fedora:40
         sudo dnf -y install cuda-12-6
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
+        # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
+        sudo dnf -y config-manager --add-repo https://negativo17.org/repos/fedora-multimedia.repo
+        sudo dnf -y clean all
+        sudo dnf -y install cuda-gcc
+        source /etc/profile.d/cuda-gcc.sh
     fi
 
     flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
@@ -756,6 +761,9 @@ From: fedora:40
         echo export CUDA_HOME=/usr/local/cuda >> $INSTALLDIR/init.sh
         echo export PATH=\$CUDA_HOME/bin:\$PATH >> $INSTALLDIR/init.sh
         echo export LD_LIBRARY_PATH=\$CUDA_HOME/lib64:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
+       # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
+        echo export NVCC_CCBIN=g++-13 >> $INSTALLDIR/init.sh
+        echo export NVCC_PREPEND_FLAGS='-ccbin /usr/bin/g++-13' >> $INSTALLDIR/init.sh
     fi
     echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
     echo flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh

--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -762,8 +762,7 @@ From: fedora:40
         echo export PATH=\$CUDA_HOME/bin:\$PATH >> $INSTALLDIR/init.sh
         echo export LD_LIBRARY_PATH=\$CUDA_HOME/lib64:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
        # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
-        echo export NVCC_CCBIN=g++-13 >> $INSTALLDIR/init.sh
-        echo export NVCC_PREPEND_FLAGS='-ccbin /usr/bin/g++-13' >> $INSTALLDIR/init.sh
+        echo "source /etc/profile.d/cuda-gcc.sh" >> $INSTALLDIR/init.sh
     fi
     echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
     echo flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh

--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -197,7 +197,7 @@ From: fedora:40
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
         # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
-        sudo dnf -y config-manager --add-repo https://negativo17.org/repos/fedora-multimedia.repo
+        sudo dnf -y config-manager --add-repo https://copr.fedorainfracloud.org/coprs/slaanesh/cuda-gcc/repo/fedora-40/slaanesh-cuda-gcc-fedora-40.repo
         sudo dnf -y clean all
         sudo dnf -y install cuda-gcc
         source /etc/profile.d/cuda-gcc.sh

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -166,7 +166,7 @@ EOF
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
         # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
-        sudo dnf -y config-manager --add-repo https://negativo17.org/repos/fedora-multimedia.repo
+        sudo dnf -y config-manager --add-repo https://copr.fedorainfracloud.org/coprs/slaanesh/cuda-gcc/repo/fedora-40/slaanesh-cuda-gcc-fedora-40.repo
         sudo dnf -y clean all
         sudo dnf -y install cuda-gcc
         source /etc/profile.d/cuda-gcc.sh

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -165,6 +165,11 @@ EOF
         sudo dnf -y install cuda-12-6
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
+        # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
+        sudo dnf -y config-manager --add-repo https://negativo17.org/repos/fedora-multimedia.repo
+        sudo dnf -y clean all
+        sudo dnf -y install cuda-gcc
+        source /etc/profile.d/cuda-gcc.sh
     fi
 
     flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
@@ -720,6 +725,9 @@ EOF
         echo export CUDA_HOME=/usr/local/cuda >> $INSTALLDIR/init.sh
         echo export PATH=\$CUDA_HOME/bin:\$PATH >> $INSTALLDIR/init.sh
         echo export LD_LIBRARY_PATH=\$CUDA_HOME/lib64:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
+       # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
+        echo export NVCC_CCBIN=g++-13 >> $INSTALLDIR/init.sh
+        echo export NVCC_PREPEND_FLAGS='-ccbin /usr/bin/g++-13' >> $INSTALLDIR/init.sh
     fi
     echo export HAS_MKL=$HAS_MKL >> $INSTALLDIR/init.sh
     echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -726,8 +726,7 @@ EOF
         echo export PATH=\$CUDA_HOME/bin:\$PATH >> $INSTALLDIR/init.sh
         echo export LD_LIBRARY_PATH=\$CUDA_HOME/lib64:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
        # Make CUDA 12.6 work with GCC 14. Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/
-        echo export NVCC_CCBIN=g++-13 >> $INSTALLDIR/init.sh
-        echo export NVCC_PREPEND_FLAGS='-ccbin /usr/bin/g++-13' >> $INSTALLDIR/init.sh
+        echo "source /etc/profile.d/cuda-gcc.sh" >> $INSTALLDIR/init.sh
     fi
     echo export HAS_MKL=$HAS_MKL >> $INSTALLDIR/init.sh
     echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh


### PR DESCRIPTION
# Description

This is the base to add CUDA to DP3 and Sagecal.
Explanation: https://negativo17.org/cuda-with-unsupported-gcc-versions/

Related: https://github.com/tikk3r/flocs/pull/151, https://github.com/tikk3r/flocs/pull/152.