### PR TITLE
Remove `DOpenBLAS_LIB` from SageCal AMD

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -365,8 +365,7 @@ From: fedora:40
     cd $INSTALLDIR/sagecal
     git clone https://github.com/nlesc-dirac/sagecal.git src
     cd build
-    cmake $CMAKE_ADD_OPTION -DOpenBLAS_LIB=/opt/OpenBLAS/lib64/libopenblas.so \
-        -DBLA_VENDOR=AOCL_mt \
+    cmake $CMAKE_ADD_OPTION -DBLA_VENDOR=AOCL_mt \
         -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/sagecal \
         -DLIB_ONLY=True \
         ../src


### PR DESCRIPTION
# Description

It is no longer needed since AOCL is there. Also to make sure that AOCL is used.

BEFORE:
> -- OpenBLAS_LIB .............. = /opt/OpenBLAS/lib64/libopenblas.so
> [...]
> -- LAPACK_LIBRARIES........... = /opt/aocl/4.0/lib/libflame.so;/opt/aocl/4.0/lib/libblis-mt.so;-fopenmp
> [...]
> BLAS_blis_mt_LIBRARY:FILEPATH=/opt/aocl/4.0/lib/libblis-mt.so

AFTER:
> -- Found BLAS: /opt/aocl/4.0/lib/libblis-mt.so
> -- Using BLAS: AOCL_mt
> [...]
> -- LAPACK_LIBRARIES........... = /opt/aocl/4.0/lib/libflame.so;/opt/aocl/4.0/lib/libblis-mt.so;-fopenmp
> [...]
> BLAS_blis_mt_LIBRARY:FILEPATH=/opt/aocl/4.0/lib/libblis-mt.so