### PR TITLE
Remove `-march` from EveryBeam AMD

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -420,8 +420,8 @@ From: fedora:40
         -DBUILD_WITH_PYTHON=ON \
         -DFFTW3F_LIBRARY="${AOCL_ROOT}/lib/libfftw3f.so" \
         -DLAPACK_LIBRARIES="${AOCL_ROOT}/lib/libflame.so" \
-        -DCMAKE_CXX_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
-        -DCMAKE_C_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
+        -DCMAKE_CXX_FLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
+        -DCMAKE_C_FLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
         -DBLA_VENDOR=AOCL_mt \
         -DTARGET_CPU=$MARCH \
         ../src


### PR DESCRIPTION
# Description

`-DTARGET_CPU=$MARCH` is there.