### PR TITLE
Use MKL in NumPy and SciPy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,6 @@ nmmn
 nose
 numdifftools
 numexpr
-numpy<2
 oauthlib
 pluggy
 polars
@@ -112,7 +111,6 @@ ruamel.yaml
 SciencePlots
 scikit-build
 scikit-learn
-scipy
 seaborn
 shapely
 sharedarray

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,6 +71,7 @@ nmmn
 nose
 numdifftools
 numexpr
+numpy<2
 oauthlib
 pluggy
 polars

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -220,6 +220,7 @@ EOF
         cd numpy-1.26.4/
         pip install . -Csetup-args=-Dblas-order=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack-order=mkl-dynamic-lp64-iomp -Csetup-args=-Db_lto=true
         if [ $DEBUG = true ]; then
+            pip install pyyaml
             python -c 'import numpy; numpy.show_config()'
         fi
         cd ..
@@ -231,6 +232,7 @@ EOF
         cd scipy-1.15.1/
         pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp -Csetup-args=-Db_lto=true
         if [ $DEBUG = true ]; then
+            pip install pyyaml
             python -c 'import numpy; numpy.show_config()'
         fi
         cd ..

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -218,7 +218,7 @@ EOF
         tar xzf numpy-1.26.4.tar.gz
         rm numpy-1.26.4.tar.gz
         cd numpy-1.26.4/
-        python -m pip install . -Csetup-args=-Dblas-order=mkl,openblas,blis -Csetup-args=-Dlapack-order=mkl,openblas,lapack
+        pip install . -Csetup-args=-Dblas-order=mkl,openblas,blis -Csetup-args=-Dlapack-order=mkl,openblas,lapack
         cd ..
         rm -rf numpy-1.26.4/
 
@@ -226,11 +226,11 @@ EOF
         tar xzf scipy-1.15.1.tar.gz
         rm scipy-1.15.1.tar.gz
         cd scipy-1.15.1/
-        export PKG_CONFIG_PATH=$MKLROOT/lib/pkgconfig/
-        ls $PKG_CONFIG_PATH
-        python -m pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp
+        pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp
         cd ..
         rm -rf scipy-1.15.1/
+
+        export PKG_CONFIG_PATH=$MKLROOT/lib/pkgconfig/
     else
         pip install "numpy<2"
     fi

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -218,7 +218,7 @@ EOF
         tar xzf numpy-1.26.4.tar.gz
         rm numpy-1.26.4.tar.gz
         cd numpy-1.26.4/
-        pip install . -Csetup-args=-Dblas-order=mkl,openblas,blis -Csetup-args=-Dlapack-order=mkl,openblas,lapack
+        pip install . -Csetup-args=-Dblas-order=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack-order=mkl-dynamic-lp64-iomp
         cd ..
         rm -rf numpy-1.26.4/
 

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -213,7 +213,7 @@ EOF
     rm -rf datashape-0.5.2/
 
     pip install --upgrade pip wheel Cython
-    if [ $HAS_MKL = true ]; then
+    if [ $MARCH = 'native' ] && [ $MTUNE = 'native' ] && [ $HAS_MKL = true ]; then
         wget https://github.com/numpy/numpy/releases/download/v1.26.4/numpy-1.26.4.tar.gz
         tar xzf numpy-1.26.4.tar.gz
         rm numpy-1.26.4.tar.gz

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -215,7 +215,7 @@ EOF
     pip install --upgrade pip wheel Cython
     if [ $HAS_MKL = true ]; then
         wget https://github.com/numpy/numpy/releases/download/v1.26.4/numpy-1.26.4.tar.gz
-        tar xvzf numpy-1.26.4.tar.gz
+        tar xzf numpy-1.26.4.tar.gz
         rm numpy-1.26.4.tar.gz
         cd numpy-1.26.4/
         python -m pip install . -Csetup-args=-Dblas-order=mkl,openblas,blis -Csetup-args=-Dlapack-order=mkl,openblas,lapack
@@ -223,7 +223,7 @@ EOF
         rm -rf numpy-1.26.4/
 
         wget https://github.com/scipy/scipy/releases/download/v1.15.1/scipy-1.15.1.tar.gz
-        tar xvzf scipy-1.15.1.tar.gz
+        tar xzf scipy-1.15.1.tar.gz
         rm scipy-1.15.1.tar.gz
         cd scipy-1.15.1/
         export PKG_CONFIG_PATH=$MKLROOT/lib/pkgconfig/

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -219,6 +219,9 @@ EOF
         rm numpy-1.26.4.tar.gz
         cd numpy-1.26.4/
         pip install . -Csetup-args=-Dblas-order=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack-order=mkl-dynamic-lp64-iomp
+        if [ $DEBUG = true ]; then
+            python -c 'import numpy; numpy.show_config()'
+        fi
         cd ..
         rm -rf numpy-1.26.4/
 
@@ -227,6 +230,9 @@ EOF
         rm scipy-1.15.1.tar.gz
         cd scipy-1.15.1/
         pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp
+        if [ $DEBUG = true ]; then
+            python -c 'import numpy; numpy.show_config()'
+        fi
         cd ..
         rm -rf scipy-1.15.1/
 

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -240,7 +240,7 @@ EOF
 
         export PKG_CONFIG_PATH=$MKLROOT/lib/pkgconfig/
     else
-        pip install "numpy<2"
+        pip install "numpy<2" scipy
     fi
     pip install --no-binary pandas pandas
     pip install --no-binary h5py h5py

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -218,7 +218,7 @@ EOF
         tar xzf numpy-1.26.4.tar.gz
         rm numpy-1.26.4.tar.gz
         cd numpy-1.26.4/
-        pip install . -Csetup-args=-Dblas-order=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack-order=mkl-dynamic-lp64-iomp
+        pip install . -Csetup-args=-Dblas-order=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack-order=mkl-dynamic-lp64-iomp -Csetup-args=-Db_lto=true
         if [ $DEBUG = true ]; then
             python -c 'import numpy; numpy.show_config()'
         fi
@@ -229,7 +229,7 @@ EOF
         tar xzf scipy-1.15.1.tar.gz
         rm scipy-1.15.1.tar.gz
         cd scipy-1.15.1/
-        pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp
+        pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp -Csetup-args=-Db_lto=true
         if [ $DEBUG = true ]; then
             python -c 'import numpy; numpy.show_config()'
         fi

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -213,7 +213,27 @@ EOF
     rm -rf datashape-0.5.2/
 
     pip install --upgrade pip wheel Cython
-    pip install "numpy<2"
+    if [ $HAS_MKL = true ]; then
+        wget https://github.com/numpy/numpy/releases/download/v1.26.4/numpy-1.26.4.tar.gz
+        tar xvzf numpy-1.26.4.tar.gz
+        rm numpy-1.26.4.tar.gz
+        cd numpy-1.26.4/
+        python -m pip install . -Csetup-args=-Dblas-order=mkl,openblas,blis -Csetup-args=-Dlapack-order=mkl,openblas,lapack
+        cd ..
+        rm -rf numpy-1.26.4/
+
+        wget https://github.com/scipy/scipy/releases/download/v1.15.1/scipy-1.15.1.tar.gz
+        tar xvzf scipy-1.15.1.tar.gz
+        rm scipy-1.15.1.tar.gz
+        cd scipy-1.15.1/
+        export PKG_CONFIG_PATH=$MKLROOT/lib/pkgconfig/
+        ls $PKG_CONFIG_PATH
+        python -m pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp
+        cd ..
+        rm -rf scipy-1.15.1/
+    else
+        pip install "numpy<2"
+    fi
     pip install --no-binary pandas pandas
     pip install --no-binary h5py h5py
     pip install -r $INSTALLDIR/flocs/requirements.txt
@@ -741,6 +761,7 @@ EOF
         echo export MKLROOT=$MKLROOT >> $INSTALLDIR/init.sh
         echo export PATH=\$MKLROOT/bin:\$PATH >> $INSTALLDIR/init.sh
         echo export LD_LIBRARY_PATH=\$MKLROOT/lib:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
+        echo export PKG_CONFIG_PATH=\$PKG_CONFIG_PATH >> $INSTALLDIR/init.sh
     fi
 
 

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -226,17 +226,17 @@ EOF
         cd ..
         rm -rf numpy-1.26.4/
 
-        wget https://github.com/scipy/scipy/releases/download/v1.15.1/scipy-1.15.1.tar.gz
-        tar xzf scipy-1.15.1.tar.gz
-        rm scipy-1.15.1.tar.gz
-        cd scipy-1.15.1/
+        wget https://github.com/scipy/scipy/releases/download/v1.15.2/scipy-1.15.2.tar.gz
+        tar xzf scipy-1.15.2.tar.gz
+        rm scipy-1.15.2.tar.gz
+        cd scipy-1.15.2/
         pip install . -Csetup-args=-Dblas=mkl-dynamic-lp64-iomp -Csetup-args=-Dlapack=mkl-dynamic-lp64-iomp -Csetup-args=-Db_lto=true
         if [ $DEBUG = true ]; then
             pip install pyyaml
             python -c 'import numpy; numpy.show_config()'
         fi
         cd ..
-        rm -rf scipy-1.15.1/
+        rm -rf scipy-1.15.2/
 
         export PKG_CONFIG_PATH=$MKLROOT/lib/pkgconfig/
     else


### PR DESCRIPTION
# Description

This builds NumPy and Scipy against MKL. I think it is better this way than https://github.com/tikk3r/flocs/issues/98, since no extra large packages are installed (https://github.com/tikk3r/flocs/issues/98#issuecomment-2599681373).
It does compile. Import numpy and scipy works.
It requires benchmarks. For example, LSMTool and PyBDSF use Numpy and Scipy a lot (https://git.astron.nl/RD/rapthor/-/issues/31).

BTW:
>       CPU Optimization Options
>         baseline:
>           Requested : min+detect
>           Enabled   : SSE SSE2 SSE3 SSSE3 SSE41 POPCNT SSE42 AVX F16C FMA3 AVX2
>         dispatch:
>           Requested : max -xop -fma4
>           Enabled   : AVX512F AVX512CD AVX512_KNL AVX512_KNM AVX512_SKX AVX512_CLX AVX512_CNL AVX512_ICL AVX512_SPR

So it seems that AVX2 is used by default in NumPy and everything "above" is dispatched.