### PR TITLE
Remove `DLAPACK_LIBRARIES` from EveryBeam AMD

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -419,7 +419,6 @@ From: fedora:40
         -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/EveryBeam \
         -DBUILD_WITH_PYTHON=ON \
         -DFFTW3F_LIBRARY="${AOCL_ROOT}/lib/libfftw3f.so" \
-        -DLAPACK_LIBRARIES="${AOCL_ROOT}/lib/libflame.so" \
         -DCMAKE_CXX_FLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
         -DCMAKE_C_FLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
         -DBLA_VENDOR=AOCL_mt \


### PR DESCRIPTION
# Description

`-DBLA_VENDOR=AOCL_mt` is there.
BEFORE:
> -- Found BLAS: /opt/aocl/4.0/lib/libblis-mt.so
> -- Found LAPACK: /opt/aocl/4.0/lib/libflame.so

AFTER:
> -- Found BLAS: /opt/aocl/4.0/lib/libblis-mt.so
> [...]
> -- Found LAPACK: /opt/aocl/4.0/lib/libflame.so;/opt/aocl/4.0/lib/libblis-mt.so;-fopenmp