### PR TITLE
Remove duplicated `march` from CASACore AMD

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -327,8 +327,8 @@ From: fedora:40
         -DFFTW3F_LIBRARY="${AOCL_ROOT}/lib/libfftw3f.so" \
         -DFFTW3F_THREADS_LIBRARY="${AOCL_ROOT}/lib/libfftw3f_threads.so" \
         -DFFTW3_INCLUDE_DIR="${AOCL_ROOT}/include" \
-        -DCMAKE_CXX_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
-        -DCMAKE_C_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
+        -DCMAKE_CXX_FLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
+        -DCMAKE_C_FLAGS="-L${AOCL_ROOT}/lib -lamdlibm -lblis -lm -O3 -Ofast" \
         -DBLA_VENDOR=AOCL_mt \
         ../src
     cd ${INSTALLDIR}/casacore/build && make -s -j ${J}


### PR DESCRIPTION
# Description

This is also passed by env varibales.