### PR TITLE
Add MKL libs for CASACore

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -285,16 +285,29 @@ EOF
     ncftpget ftp://anonymous@ftp.astron.nl/outgoing/Measures/WSRT_Measures.ztar
     tar xf WSRT_Measures.ztar && rm WSRT_Measures.ztar
     cd ${INSTALLDIR}/casacore/build
-    cmake $CMAKE_ADD_OPTION \
-        -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/casacore/ \
-        -DDATA_DIR=${INSTALLDIR}/casacore/data \
-        -DBUILD_PYTHON=False \
-        -DUSE_OPENMP=True \
-        -DUSE_HDF5=True \
-        -DBUILD_PYTHON3=True \
-        -DBUILD_DYSCO=OFF \
-        -DBLAS_LIBRARIES=/opt/OpenBLAS/lib64/libopenblas.so \
-        ../src/ 
+    if [ $HAS_MKL = true ]; then
+        cmake $CMAKE_ADD_OPTION \
+            -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/casacore/ \
+            -DDATA_DIR=${INSTALLDIR}/casacore/data \
+            -DBUILD_PYTHON=False \
+            -DUSE_OPENMP=True \
+            -DUSE_HDF5=True \
+            -DBUILD_PYTHON3=True \
+            -DBUILD_DYSCO=OFF \
+            -DBLA_VENDOR=Intel10_64lp \
+            ../src
+    else
+        cmake $CMAKE_ADD_OPTION \
+            -DCMAKE_INSTALL_PREFIX=${INSTALLDIR}/casacore/ \
+            -DDATA_DIR=${INSTALLDIR}/casacore/data \
+            -DBUILD_PYTHON=False \
+            -DUSE_OPENMP=True \
+            -DUSE_HDF5=True \
+            -DBUILD_PYTHON3=True \
+            -DBUILD_DYSCO=OFF \
+            -DBLAS_LIBRARIES=/opt/OpenBLAS/lib64/libopenblas.so \
+            ../src
+    fi
     cd ${INSTALLDIR}/casacore/build && make -s -j ${J}
     cd ${INSTALLDIR}/casacore/build && make install
     cd $INSTALLDIR


### PR DESCRIPTION
# Description

Add `-DBLA_VENDOR=Intel10_64lp` after condition.

BEFORE:
```
-- Found BLAS: /opt/OpenBLAS/lib64/libopenblas.so
[...]
-- Found LAPACK: /opt/OpenBLAS/lib64/libopenblas.so;-lm;-ldl
[...]
-- BLAS library? ......... = /opt/OpenBLAS/lib64/libopenblas.so
-- LAPACK library? ....... = /opt/OpenBLAS/lib64/libopenblas.so;-lm;-ldl
```


AFTER:
```
-- Found BLAS: /opt/intel/oneapi/mkl/2025.0/lib/libmkl_gf_lp64.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_gnu_thread.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_core.so;/usr/lib/gcc/x86_64-redhat-linux/14/libgomp.so;-lm;-ldl
[...]
-- Found LAPACK: /opt/intel/oneapi/mkl/2025.0/lib/libmkl_gf_lp64.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_gnu_thread.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_core.so;/usr/lib/gcc/x86_64-redhat-linux/14/libgomp.so;-lm;-ldl;-lm;-ldl
[...]
-- BLAS library? ......... = /opt/intel/oneapi/mkl/2025.0/lib/libmkl_gf_lp64.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_gnu_thread.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_core.so;/usr/lib/gcc/x86_64-redhat-linux/14/libgomp.so;-lm;-ldl
-- LAPACK library? ....... = /opt/intel/oneapi/mkl/2025.0/lib/libmkl_gf_lp64.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_gnu_thread.so;/opt/intel/oneapi/mkl/2025.0/lib/libmkl_core.so;/usr/lib/gcc/x86_64-redhat-linux/14/libgomp.so;-lm;-ldl;-lm;-ldl
```