### PR TITLE
Update cuda to 12.8

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -182,11 +182,11 @@ From: fedora:40
 
     if [ $HAS_CUDA = true ]; then
         #
-        # Install CUDA 12.6
+        # Install CUDA 12.8
         #
-        sudo dnf -y config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/fedora39/x86_64/cuda-fedora39.repo
+        sudo dnf -y config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/fedora41/x86_64/cuda-fedora41.repo
         sudo dnf -y clean all
-        sudo dnf -y install cuda-12-6
+        sudo dnf -y install cuda-12-8
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
     fi

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -150,11 +150,11 @@ EOF
 
     if [ $HAS_CUDA = true ]; then
         #
-        # Install CUDA 12.6
+        # Install CUDA 12.8
         #
-        sudo dnf -y config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/fedora39/x86_64/cuda-fedora39.repo
+        sudo dnf -y config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/fedora41/x86_64/cuda-fedora41.repo
         sudo dnf -y clean all
-        sudo dnf -y install cuda-12-6
+        sudo dnf -y install cuda-12-8
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
     fi


### PR DESCRIPTION
# Description

https://github.com/tikk3r/flocs/pull/208 still does not build, but I checked that it builds without enabling CUDA in DP3 (https://github.com/tikk3r/flocs/pull/208). Sagecal against CUDA 12.8 (https://github.com/tikk3r/flocs/pull/152) builds fine.
12.8 seems to be better for Fedora 40 as it supports GCC 14: https://docs.nvidia.com/cuda/cuda-installation-guide-linux/#id47.