### PR TITLE
Add openssl11

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -89,6 +89,8 @@ From: fedora:40
     # Necessary for nomacs
     sudo strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so.5
 
+    dnf -y install https://na.edge.kernel.org/fedora/releases/39/Everything/x86_64/os/Packages/o/openssl1.1-1.1.1q-5.fc39.x86_64.rpm
+
     # Install OpenBLAS
     mkdir -p /opt/OpenBLAS
     cd /opt/OpenBLAS

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -88,6 +88,8 @@ From: fedora:40
     # Necessary for nomacs
     sudo strip --remove-section=.note.ABI-tag /usr/lib64/libQt5Core.so.5
 
+    dnf -y install https://na.edge.kernel.org/fedora/releases/39/Everything/x86_64/os/Packages/o/openssl1.1-1.1.1q-5.fc39.x86_64.rpm
+
     export CC=`which gcc`
     export CXX=`which g++`
     


### PR DESCRIPTION
add openssl11, this is required for casa, otherwise you get an `Exception: Unexpected exception while getting list of available casarundata versions : name 'HTTPSHandler' is not defined`

