### PR TITLE
Update the default calib_nchan to 1

### DIFF
--- a/runners/create_ms_list.py
+++ b/runners/create_ms_list.py
@@ -793,7 +793,7 @@ def add_arguments_linc_target(parser):
     parser.add_argument(
         "--calib_nchan",
         type=int,
-        default=None,
+        default=1,
         help="Number of channels to combine during the phase calibration. 0 means combine all channels.",
     )
     parser.add_argument(


### PR DESCRIPTION
# Description

Updates create_ms_list.py to use `calib_nchan=1` in preparation of https://git.astron.nl/RD/LINC/-/merge_requests/253