### PR TITLE
add casapy support Singularity.intel_mkl

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -13,6 +13,7 @@ From: fedora:40
         NOAVX512=true
         DEBUG=false
         OPENBLASTARGET=SANDYBRIDGE
+        INSTALL_CASA=false
 
 %post
     # General environment settings.
@@ -43,6 +44,7 @@ From: fedora:40
     export MTUNE={{ MTUNE }}
     export NOAVX512={{ NOAVX512 }}
     export DEBUG={{ DEBUG }}
+    export INSTALL_CASA={{ INSTALL_CASA }}
 
     export CPPSTD=c++17
     export OMP_NUM_THREADS=1
@@ -195,6 +197,33 @@ EOF
     uv venv --seed --python=python3 $INSTALLDIR/pyenv-py3
     # Without this strange bash errors appear with singularity shell from apptainer with 1.1.6-1.el8.
     source $INSTALLDIR/pyenv-py3/bin/activate
+
+    #
+    # Install Casapy
+    #
+    if [ $INSTALL_CASA = true ]; then
+       dnf -y install https://na.edge.kernel.org/fedora/releases/39/Everything/x86_64/os/Packages/o/openssl1.1-1.1.1q-5.fc39.x86_64.rpm
+       dnf -y install fuse fuse-libs
+       dnf -y install https://dl.fedoraproject.org/pub/fedora/linux/updates/40/Everything/x86_64/Packages/g/git-lfs-3.6.1-1.fc40.x86_64.rpm
+    
+       mkdir -p /opt/casa
+       cd /opt/casa
+       wget https://casa.nrao.edu/download/distro/casa/release/rhel/casa-6.7.0-31-py3.12.el8.tar.xz
+       unxz casa-6.7.0-31-py3.12.el8.tar.xz
+       tar xf casa-6.7.0-31-py3.12.el8.tar
+       rm -f casa-6.7.0-31-py3.12.el8.tar
+       echo export PATH=/opt/casa/casa-6.7.0-31-py3.12.el8/bin/:\$PATH  >> $INSTALLDIR/init.sh
+       
+       #virtualenv $INSTALLDIR/pyenv-casatasks --python=python3
+       #Without this strange bash errors appear with singularity shell from apptainer with 1.1.6-1.el8.
+       #printf "unset \$PROMPT_COMMAND\n$(cat $INSTALLDIR/pyenv-py3/bin/activate)" > $INSTALLDIR/pyenv-casatasks/bin/activate
+       #source $INSTALLDIR/pyenv-casatasks/bin/activate    
+       pip install casaconfig==1.3.1
+       pip install casatasks==6.7.0.31
+       pip install casatestutils==6.7.0.31
+       pip install casadata==2025.3.17
+       #echo export PYTHONPATH=\$INSTALLDIR/DP3/bin:\$PYTHONPATH  >> $INSTALLDIR/init.sh
+    fi    
 
     uv pip install --upgrade pip wheel Cython "setuptools>=59.5.0,<71"
     uv pip install "numpy<2"


### PR DESCRIPTION
-add support for installing casa (default is false which, in that case this commit does not affect anything)

- if INSTALL_CASA = true then casapy will be installed. This allows running casapy tasks in python (due to library conflicts it is best to not import the casapy libs in lofar-related python code but rather invoke just it via os.system(python /path/script_that_uses_casapythonlibs.py for example)

*delete before opening*

When updating a PR: please *rebase* feature branches on the main branch for a cleaner commit history ("update with rebase" on github).

Performance-related PRs will not be accepted without benchmarks of realistic usecases showing a performance improvement. See the benchmarks folder for examples.

# Description

Describe what this PR implements or fixes.
