### PR TITLE
Avoid multiple uv warnings

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -218,6 +218,7 @@ From: fedora:42
     #
     sudo dnf -y install python3-cx-oracle python3.12 python3.12-devel
     pip install uv
+    export PATH="/root/.local/bin:$PATH"
 
     uv tool install shadems
     uv tool install lofar-vlbi-plot

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -188,6 +188,7 @@ EOF
     #
     sudo dnf -y install python3-cx-oracle python3.12 python3.12-devel
     pip install uv
+    export PATH="/root/.local/bin:$PATH"
 
     uv tool install shadems
     uv tool install lofar-vlbi-plot


### PR DESCRIPTION
*Description*

This is to avoid:

> warning: `/root/.local/bin` is not on your PATH. To use installed tools, run `export PATH="/root/.local/bin:$PATH"` or `uv tool update-shell`.
