### PR TITLE
Remove setting the GCC alternatives

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -87,9 +87,6 @@ From: fedora:42
     wget https://raw.githubusercontent.com/tikk3r/flocs/fedora-py3/dnf-packages.txt -O $INSTALLDIR/dnf-packages.txt
     dnf -y install $(<$INSTALLDIR/dnf-packages.txt)
 
-    sudo alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
-    sudo alternatives --set gcc /usr/bin/gcc-14
-
     wget --progress=bar:force:noscroll https://download.oracle.com/otn_software/linux/instantclient/2360000/oracle-instantclient-basic-23.6.0.24.10-1.el9.x86_64.rpm
     dnf -y install oracle-instantclient-basic-23.6.0.24.10-1.el9.x86_64.rpm
     rm oracle-instantclient-basic-*.rpm

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -86,9 +86,6 @@ From: fedora:42
     wget https://raw.githubusercontent.com/tikk3r/flocs/fedora-py3/dnf-packages.txt -O $INSTALLDIR/dnf-packages.txt
     dnf -y install $(<$INSTALLDIR/dnf-packages.txt)
 
-    sudo alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
-    sudo alternatives --set gcc /usr/bin/gcc-14
-
     wget --progress=bar:force:noscroll https://download.oracle.com/otn_software/linux/instantclient/2360000/oracle-instantclient-basic-23.6.0.24.10-1.el9.x86_64.rpm
     dnf -y install oracle-instantclient-basic-23.6.0.24.10-1.el9.x86_64.rpm
     rm oracle-instantclient-basic-*.rpm


### PR DESCRIPTION
# Description

> + sudo alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140
> failed to link /usr/bin/gcc -> /etc/alternatives/gcc: /usr/bin/gcc exists and it is not a symlink
> + sudo alternatives --set gcc /usr/bin/gcc-14
> failed to link /usr/bin/gcc -> /etc/alternatives/gcc: /usr/bin/gcc exists and it is not a symlink

So it wasn't working anyway. It does compile without it, though.