### PR TITLE
Remove Armadillo

### DIFF
--- a/dnf-packages.txt
+++ b/dnf-packages.txt
@@ -1,5 +1,3 @@
-armadillo
-armadillo-devel
 arpack-devel
 autoconf
 automake


### PR DESCRIPTION
# Description

After installation, the phrase `armadillo` does not appear in the logs. It seems that nothing is linking to it.