### PR TITLE
Remove boost from `requirements.txt`

### DIFF
--- a/requirements_ci.txt
+++ b/requirements_ci.txt
@@ -12,7 +12,6 @@ backports.ssl-match-hostname
 bces
 bilby
 blurhash
-boost
 breizorro
 cachetools
 certifi


### PR DESCRIPTION
# Description

Boost Python is now installed from the recipe. It does build.