### PR TITLE
Clean UV cache

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -665,7 +665,7 @@ From: fedora:42
     rm -rf /var/cache/dnf/*
     rm -rf /var/cache/yum/*
     rm -rf /var/log/*
-    rm -rf /root/.cache/uv/*
+    uv cache clean
     dnf -y clean all
     
     #

--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -665,6 +665,7 @@ From: fedora:42
     rm -rf /var/cache/dnf/*
     rm -rf /var/cache/yum/*
     rm -rf /var/log/*
+    rm -rf /root/.cache/uv/*
     dnf -y clean all
     
     #

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -640,7 +640,7 @@ EOF
     rm -rf /var/cache/dnf/*
     rm -rf /var/cache/yum/*
     rm -rf /var/log/*
-    rm -rf /root/.cache/uv/*
+    uv cache clean
     dnf -y clean all
     
     #

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -640,6 +640,7 @@ EOF
     rm -rf /var/cache/dnf/*
     rm -rf /var/cache/yum/*
     rm -rf /var/log/*
+    rm -rf /root/.cache/uv/*
     dnf -y clean all
     
     #


### PR DESCRIPTION
# Description

This folder is 12 GB in size. There is eg.:

> 996M /root/.cache/uv/archive-v0/DVo3GyRJjhBea6tvJWe0B/torch/lib/libtorch_cuda.so

The image is reduced by 600 MB.