### PR TITLE
Clean MKLs compiler

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -640,6 +640,7 @@ EOF
     rm -rf /var/cache/dnf/*
     rm -rf /var/cache/yum/*
     rm -rf /var/log/*
+    rm -rf /opt/intel/oneapi/compiler/latest/bin/*
     uv cache clean
     dnf -y clean all
     


### PR DESCRIPTION
# Description

203 MB. It seems this is never used, especially at runtime.
"Internet wisdom" says to be careful about removing the libraries (`/opt/intel/oneapi/compiler/latest/lib/`), which is why I'm only removing the executables.
The `f` option ensures safety even if the folder does not exist.