### PR TITLE
Add `filter=blob:none` to CASACore

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -297,7 +297,7 @@ From: fedora:42
     mkdir -p ${INSTALLDIR}/casacore/build
     mkdir -p ${INSTALLDIR}/casacore/data
     cd $INSTALLDIR/casacore
-    git clone --single-branch --branch master https://github.com/casacore/casacore.git src
+    git clone --single-branch --filter=blob:none --branch master https://github.com/casacore/casacore.git src
     cd ${INSTALLDIR}/casacore/src && git checkout ${CASACORE_VERSION} && echo export CASACORE_VERSION=$(git rev-parse --short HEAD) >> $INSTALLDIR/init.sh
     cd ${INSTALLDIR}/casacore/data
     wget -nv https://www.astron.nl/iers/WSRT_Measures.ztar

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -268,7 +268,7 @@ EOF
     mkdir -p ${INSTALLDIR}/casacore/build
     mkdir -p ${INSTALLDIR}/casacore/data
     cd $INSTALLDIR/casacore
-    git clone --single-branch --branch master https://github.com/casacore/casacore.git src
+    git clone --single-branch --filter=blob:none --branch master https://github.com/casacore/casacore.git src
     cd ${INSTALLDIR}/casacore/src && git checkout ${CASACORE_VERSION} && echo export CASACORE_VERSION=$(git rev-parse --short HEAD) >> $INSTALLDIR/init.sh
     cd ${INSTALLDIR}/casacore/data
     wget -nv https://www.astron.nl/iers/WSRT_Measures.ztar


### PR DESCRIPTION
# Description

The size of the downloaded and checked-out folder has decreased from 147 MB to 88 MB. This should stay beneficial, provided the checked-out commit is not too old.