### PR TITLE
Remove `libmkl_sycl.a`

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -647,7 +647,8 @@ EOF
     rm -rf /var/log/*
     uv cache clean
     dnf -y clean all
-    
+    rm -f /opt/intel/oneapi/mkl/latest/lib/libmkl_sycl.a
+
     #
     # init-lofar
     #


### PR DESCRIPTION
# Description

This seems to have never been used, as all the SYCL. This file is almost 1 GB.
It reduces the image size by 200 MB.