### PR TITLE
Fix `libiomp5.so`

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -105,6 +105,7 @@ EOF
         sudo mv /tmp/oneAPI.repo /etc/yum.repos.d/
         dnf -y install intel-oneapi-mkl intel-oneapi-mkl-devel
         # We don't compile with the Intel toolchain
+        mv /opt/intel/oneapi/compiler/latest/lib/libiomp5.so /opt/intel/oneapi/mkl/latest/lib/
         rm -rf /opt/intel/oneapi/compiler
         # We don't statically link
         find /opt/intel/oneapi -type f -name "*.a" -delete


### PR DESCRIPTION
# Description

This file was accidentally deleted by https://github.com/tikk3r/flocs/commit/a193d47f24a5508205ec666770708bc6f6bbdb17. Apparently, they must have moved it to `compiler/lib` at some point. It is now linked fine.