### PR TITLE
Remove SYCL MKL libs

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -105,7 +105,7 @@ EOF
         # We don't compile with the Intel toolchain
         mv /opt/intel/oneapi/compiler/latest/lib/libiomp5.so /opt/intel/oneapi/mkl/latest/lib/
         rm -rf /opt/intel/oneapi/compiler
-        # We don't statically link nor using SYCL
+        # We don't statically link nor use SYCL
         find /opt/intel/oneapi \( -type f -o -type l \) \( -name "*.a" -o -name "libmkl_sycl*" \) -delete
         source /opt/intel/oneapi/mkl/latest/env/vars.sh
     fi

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -105,8 +105,8 @@ EOF
         # We don't compile with the Intel toolchain
         mv /opt/intel/oneapi/compiler/latest/lib/libiomp5.so /opt/intel/oneapi/mkl/latest/lib/
         rm -rf /opt/intel/oneapi/compiler
-        # We don't statically link
-        find /opt/intel/oneapi -type f -name "*.a" -delete
+        # We don't statically link nor using SYCL
+        find /opt/intel/oneapi \( -type f -o -type l \) \( -name "*.a" -o -name "libmkl_sycl*" \) -delete
         source /opt/intel/oneapi/mkl/latest/env/vars.sh
     fi
 


### PR DESCRIPTION
# Description

Remove all 0.45 GB of SYCL MKL libraries and links. SYCL is neither used nor linked by any component.
The following is being removed:

> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_data_fitting.so.5
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_dft.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_vm.so.5
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_lapack.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_stats.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_data_fitting.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_sparse.so.5
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_sparse.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_blas.so.5
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_vm.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_rng.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_blas.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_dft.so.5
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_stats.so.5
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl.so
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_lapack.so.5
> /opt/intel/oneapi/mkl/2025.3/lib/libmkl_sycl_rng.so.5