### PR TITLE
Remove LINCs git objects

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -654,6 +654,7 @@ From: fedora:42
     #
     cd $INSTALLDIR
     git clone https://git.astron.nl/RD/LINC.git
+    rm -rf LINC/.git/objects/pack/
 
     # Install VLBI-cwl
     cd $INSTALLDIR

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -630,7 +630,7 @@ EOF
     #
     cd $INSTALLDIR
     git clone https://git.astron.nl/RD/LINC.git
-
+    rm -rf LINC/.git/objects/pack/
 
     # Install VLBI-cwl
     cd $INSTALLDIR


### PR DESCRIPTION
# Description

This folder is 88M. Not needed after cloning.
`git rev-parse --short HEAD` still works after this.