### PR TITLE
Better match CASACore versions

### DIFF
--- a/build_environment_variables.sh
+++ b/build_environment_variables.sh
@@ -9,7 +9,7 @@ export IDG_VERSION=9c9236d3
 export LOSOTO_VERSION=3335b05
 export OPENBLAS_VERSION=v0.3.29
 export PYBDSF_VERSION=8b33037
-export PYTHON_CASACORE_VERSION=3.6.1
+export PYTHON_CASACORE_VERSION=3.7.1
 export WSCLEAN_VERSION=v3.7
 
 # Expert settings below. Generally these won't have to be touched.


### PR DESCRIPTION
# Description

CASACore is at 3.8.0 now, so should be safer to upgrade Python-CASACore.
Now its being installed at 3.7.1 and then downgraded to 3.6.1.
The image builds fine.