### PR TITLE
Fix the build environment

### DIFF
--- a/build_environment_variables.sh
+++ b/build_environment_variables.sh
@@ -14,7 +14,7 @@ export WSCLEAN_VERSION=v3.7
 
 # Expert settings below. Generally these won't have to be touched.
 # General environment settings.
-export J=`nproc`
+export J=$(nproc)
 export INSTALLDIR=/opt/lofar
 export PYTHON_VERSION=3.12
 export HDF5_USE_FILE_LOCKING=FALSE
@@ -28,7 +28,7 @@ export OPENBLAS_NUM_THREADS=1
 export BLIS_NUM_THREADS=$OPENBLAS_NUM_THREADS
 export NUM_THREADS=256
 
-if [ $NOAVX512=true ]; then
+if [ "$NOAVX512" = "true" ]; then
     export FFLAGS="-march=${MARCH} -mtune=${MTUNE} -mno-avx512f"
     export CFLAGS="-w -march=${MARCH} -mtune=${MTUNE} -pipe -mno-avx512f"
     export CXXFLAGS="-w -march=${MARCH} -mtune=${MTUNE} -pipe -std=${CPPSTD} -mno-avx512f"
@@ -37,7 +37,7 @@ else
     export CXXFLAGS="-w -march=${MARCH} -mtune=${MTUNE} -pipe -std=${CPPSTD}"
     export FFLAGS="-march=${MARCH} -mtune=${MTUNE}"
 fi
-if [ $DEBUG=true ]; then
+if [ "$DEBUG" = "true" ]; then
     export CFLAGS="-g $CFLAGS"
     export CXXFLAGS="-g $CXXFLAGS"
     export CMAKE_ADD_OPTION="-LA"


### PR DESCRIPTION
# Description

Currently its an assignment operator always equal to true and there is a lot of `-Wno-dev` in the log even if `DEBUG=false`. The one on the left has to be in " ".

Also apply https://www.shellcheck.net/wiki/SC2006 for `J`.