### PR TITLE
Remove nsight-compute  and nsight-systems

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -148,6 +148,7 @@ From: fedora:42
         sudo dnf -y install cuda-13-0
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
+        rm -rf /opt/nvidia/
     fi
 
     flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -119,6 +119,7 @@ EOF
         sudo dnf -y install cuda-13-0
         export CUDA_HOME=/usr/local/cuda
         export PATH=$CUDA_HOME/bin:$PATH
+        rm -rf /opt/nvidia/
     fi
 
     flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so


### PR DESCRIPTION
# Description

These are 2.3 GB GUI profiling tools. Linked libraries are in `/user/local/`, not in `/opt/`. Nothing else is in `/opt/nvidia/`.
Reduces the image size by ~1 GB.