### PR TITLE
Remove flexiblas64

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -45,7 +45,7 @@ From: fedora:42
 
     export CC=`which gcc`
     export CXX=`which g++`
-    
+
     # Install OpenBLAS
     mkdir -p /opt/OpenBLAS
     cd /opt/OpenBLAS
@@ -110,7 +110,7 @@ From: fedora:42
 
     export CC=`which gcc`
     export CXX=`which g++`
-    
+
     if [ $DEBUG = true ]; then
         dnf -y install gdb valgrind mc
         debuginfo-install -y libstdc++
@@ -151,9 +151,7 @@ From: fedora:42
     fi
 
     flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
-    flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
     export FLEXIBLAS=OPENBLAS
-    export FLEXIBLAS64=OPENBLAS
     if [ $DEBUG = true ]; then
         flexiblas print
     fi
@@ -193,7 +191,7 @@ From: fedora:42
     #
     if [ $INSTALL_CASA = true ]; then
        dnf -y install fuse fuse-libs git-lfs
-    
+
        mkdir -p /opt/casa
        cd /opt/casa
        wget https://casa.nrao.edu/download/distro/casa/release/rhel/casa-6.7.0-31-py3.12.el8.tar.xz
@@ -201,7 +199,7 @@ From: fedora:42
        tar xf casa-6.7.0-31-py3.12.el8.tar
        rm -f casa-6.7.0-31-py3.12.el8.tar
        echo export PATH=/opt/casa/casa-6.7.0-31-py3.12.el8/bin/:\$PATH  >> $INSTALLDIR/init.sh
-       
+
        pip install casaconfig==1.3.1
        pip install casatasks==6.7.0.31
        pip install casatestutils==6.7.0.31
@@ -690,9 +688,7 @@ From: fedora:42
         echo export LD_LIBRARY_PATH=\$CUDA_HOME/lib64:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
     fi
     echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
-    echo flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
     echo export FLEXIBLAS=OPENBLAS >> $INSTALLDIR/init.sh
-    echo export FLEXIBLAS64=OPENBLAS >> $INSTALLDIR/init.sh
     # Needed for shadems
     echo export NUMBA_CACHE_DIR=/tmp >> $INSTALLDIR/init.sh
 

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -126,9 +126,7 @@ EOF
 
     if [ $HAS_MKL = false ]; then
         flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
-        flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
         export FLEXIBLAS=OPENBLAS
-        export FLEXIBLAS64=OPENBLAS
         if [ $DEBUG = true ]; then
             flexiblas print
         fi
@@ -663,9 +661,7 @@ EOF
     echo export HAS_MKL=$HAS_MKL >> $INSTALLDIR/init.sh
     if [ $HAS_MKL = false ]; then
         echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
-        echo flexiblas64 add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
         echo export FLEXIBLAS=OPENBLAS >> $INSTALLDIR/init.sh
-        echo export FLEXIBLAS64=OPENBLAS >> $INSTALLDIR/init.sh
     fi
     # Needed for shadems
     echo export NUMBA_CACHE_DIR=/tmp >> $INSTALLDIR/init.sh


### PR DESCRIPTION
# Description

flexiblas64 should point to `libopenblas64_.so` (ILP64 interface), not to the LP64 library. There is no `libopenblas64_.so` in `/opt/OpenBLAS`.