### PR TITLE
Remove export of `CPLUS_INCLUDE_PATH` in AOCL

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -68,7 +68,6 @@ From: fedora:42
     cd aocl-linux-aocc-5.1.0
     ./install.sh -t /opt/aocl -i lp64
     source /opt/aocl/5.1.0/aocc/amd-libs.cfg
-    export CPLUS_INCLUDE_PATH=/opt/aocl/5.1/aocc/include:$CPLUS_INCLUDE_PATH
     export CPATH=/opt/aocl/5.1.0/aocc/include:$CPATH
     # Added with Fedora 42 update, otherwise EveryBeam crashes on import.
     find /opt/aocl/5.1.0/aocc/ -name "libamdlibm*.so" -exec execstack -c {} \;


### PR DESCRIPTION
# Description

There is no `/opt/aocl/5.1/aocc/include` folder. `CPLUS_INCLUDE_PATH` is exported in `amd-libs.cfg`:

> export AOCL_ROOT=/opt/aocl/5.1.0/aocc;
> export C_INCLUDE_PATH=/opt/aocl/5.1.0/aocc/include:$C_INCLUDE_PATH
> export CPLUS_INCLUDE_PATH=/opt/aocl/5.1.0/aocc/include:$CPLUS_INCLUDE_PATH
> export LD_LIBRARY_PATH=/opt/aocl/5.1.0/aocc/lib:$LD_LIBRARY_PATH
> export LIBRARY_PATH=/opt/aocl/5.1.0/aocc/lib:$LIBRARY_PATH