### PR TITLE
Remove `DCMAKE_C_FLAGS` at WSClean AMD

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -500,7 +500,6 @@ From: fedora:42
         -DFFTW3_INCLUDE_DIR="${AOCL_ROOT}/include" \
         -DLAPACK_LIBRARIES="${AOCL_ROOT}/lib/libflame.so" \
         -DCMAKE_CXX_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
-        -DCMAKE_C_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
         -DBLA_VENDOR=AOCL_mt \
         ..
     fi


### PR DESCRIPTION
# Description

There was:

> CMake Warning:
>   Manually-specified variables were not used by the project:
> 
>     CMAKE_C_FLAGS

This is only at WSClean.