### PR TITLE
Fix AOCL detection at WSClean

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -498,7 +498,7 @@ From: fedora:42
         -DFFTW3F_LIB="${AOCL_ROOT}/lib/libfftw3f.so" \
         -DFFTW3F_THREADS_LIB="${AOCL_ROOT}/lib/libfftw3f_threads.so" \
         -DFFTW3_INCLUDE_DIR="${AOCL_ROOT}/include" \
-        -DLAPACK_LIBRARIES="${AOCL_ROOT}/lib/libflame.so" \
+        -DLAPACK_LIBRARIES="${AOCL_ROOT}/lib/libflame.so;${AOCL_ROOT}/lib/libblis.so" \
         -DCMAKE_CXX_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
         -DCMAKE_C_FLAGS="-march=${MARCH} -L${AOCL_ROOT}/lib -lamdlibm -lm -O3 -Ofast" \
         -DBLA_VENDOR=AOCL_mt \


### PR DESCRIPTION
# Description

`libflexiblas.so` was linked, where AOCL is not registered. This changes:

> -- Found BLAS: /usr/lib64/[libflexiblas.so](http://libflexiblas.so/)
> -- Found LAPACK: /usr/lib64/[libflexiblas.so;-lm;-ldl](http://libflexiblas.so;-lm;-ldl/)

to:

> -- Found BLAS: /opt/aocl/5.1.0/aocc/lib/[libblis-mt.so](http://libblis-mt.so/)
> -- Found LAPACK: /opt/aocl/5.1.0/aocc/lib/[libflame.so;/opt/aocl/5.1.0/aocc/lib/libblis.so](http://libflame.so;/opt/aocl/5.1.0/aocc/lib/libblis.so)

BTW: there is 5.2 version where they added drop-in replacement for FFTW.