### PR TITLE
Fix MultiNest build AMD

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -157,8 +157,9 @@ From: fedora:42
 
     # MultiNest
     cd $INSTALLDIR
-    git clone https://github.com/JohannesBuchner/MultiNest
-    cd MultiNest/build
+    mkdir MultiNest
+    git clone https://github.com/JohannesBuchner/MultiNest MultiNest-src
+    cd  MultiNest-src/build
     cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/MultiNest -DBLA_VENDOR=AOCL_mt ..
     make
     cd $INSTALLDIR


### PR DESCRIPTION
# Description

Make it analogous to Intel. The way it was, everything was getting deleted, including libs.