### PR TITLE
Remove AOCL ILP64 libs

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -71,6 +71,7 @@ From: fedora:42
     export CPATH=/opt/aocl/5.1.0/aocc/include:$CPATH
     # Added with Fedora 42 update, otherwise EveryBeam crashes on import.
     find /opt/aocl/5.1.0/aocc/ -name "libamdlibm*.so" -exec execstack -c {} \;
+    rm -rf /opt/aocl/5.1.0/aocc/lib_ILP64/
 
     # Get libflang.so, libpgmath.so
     mkdir -p /opt/flang


### PR DESCRIPTION
# Description

This 283 MB of libs should not be needed as long as ILP64 is not linked. Finding AOCL looks OK in the log after this.