### PR TITLE
Set FlexiBlas default to AOCL

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -150,7 +150,8 @@ From: fedora:42
     fi
 
     flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
-    export FLEXIBLAS=OPENBLAS
+    flexiblas add AOCL ${AOCL_ROOT}/lib/libblis.so
+    flexiblas default AOCL
     if [ $DEBUG = true ]; then
         flexiblas print
     fi
@@ -681,8 +682,6 @@ From: fedora:42
         echo export PATH=\$CUDA_HOME/bin:\$PATH >> $INSTALLDIR/init.sh
         echo export LD_LIBRARY_PATH=\$CUDA_HOME/lib64:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
     fi
-    echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
-    echo export FLEXIBLAS=OPENBLAS >> $INSTALLDIR/init.sh
     # Needed for shadems
     echo export NUMBA_CACHE_DIR=/tmp >> $INSTALLDIR/init.sh
 


### PR DESCRIPTION
# Description

Set flaxiblas to AOCL permanently. This can be overwritten in runtime by `export FLEXIBLAS` if needed.
Both during build and runtime `flexiblas print` gives:

> Configured BLAS libraries:
> System-wide (/etc/flexiblasrc):
>  OPENBLAS
>    library = /opt/OpenBLAS/lib64/libopenblas.so
>    comment =
>  AOCL
>    library = /opt/aocl/5.1.0/aocc/lib/libblis.so
>    comment =
> 
> System-wide from config directory (/etc/flexiblasrc.d/)
>  NETLIB
>    library = libflexiblas_netlib.so
>    comment =
>  OPENBLAS-OPENMP
>    library = libflexiblas_openblas-openmp.so
>    comment =
>  OPENBLAS-SERIAL
>    library = libflexiblas_openblas-serial.so
>    comment =
> 
> User config (/home/akurek/.flexiblasrc):
>  OPENBLAS
>    library = /opt/OpenBLAS/lib64/libopenblas.so
>    comment =
> 
> Host config (/home/akurek/.flexiblasrc.lof8):
> 
> Available hooks:
> 
> Backend and hook search paths:
>   /usr/lib64/flexiblas/
> 
> Default BLAS:
>     System:       AOCL
>     User:         (none)
>     Host:         (none)
>     Active Default: AOCL (System)

Related: https://github.com/tikk3r/flocs/issues/360.