### PR TITLE
Set FlexiBlas default to MKL (if MKL=true)

### DIFF
--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -126,10 +126,13 @@ EOF
 
     if [ $HAS_MKL = false ]; then
         flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so
-        export FLEXIBLAS=OPENBLAS
-        if [ $DEBUG = true ]; then
-            flexiblas print
-        fi
+        flexiblas default OPENBLAS
+    else
+        flexiblas add MKL $MKLROOT/lib/intel64/libmkl_rt.so
+        flexiblas default MKL
+    fi
+    if [ $DEBUG = true ]; then
+        flexiblas print
     fi
 
     # MultiNest
@@ -660,10 +663,6 @@ EOF
         echo export LD_LIBRARY_PATH=\$CUDA_HOME/lib64:\$LD_LIBRARY_PATH >> $INSTALLDIR/init.sh
     fi
     echo export HAS_MKL=$HAS_MKL >> $INSTALLDIR/init.sh
-    if [ $HAS_MKL = false ]; then
-        echo flexiblas add OPENBLAS /opt/OpenBLAS/lib64/libopenblas.so >> $INSTALLDIR/init.sh
-        echo export FLEXIBLAS=OPENBLAS >> $INSTALLDIR/init.sh
-    fi
     # Needed for shadems
     echo export NUMBA_CACHE_DIR=/tmp >> $INSTALLDIR/init.sh
 


### PR DESCRIPTION
# Description

From Radler:

> -- Found BLAS: /opt/intel/oneapi/mkl/2025.3/lib/libmkl_intel_lp64.so;/opt/intel/oneapi/mkl/2025.3/lib/libmkl_intel_thread.so;/opt/intel/oneapi/mkl/2025.3/lib/libmkl_core.so;/opt/intel/oneapi/mkl/2025.3/lib/libiomp5.so;-lm;-ldl
> -- Found LAPACK: /opt/intel/oneapi/mkl/2025.3/lib/libmkl_intel_lp64.so;/opt/intel/oneapi/mkl/2025.3/lib/libmkl_intel_thread.so;/opt/intel/oneapi/mkl/2025.3/lib/libmkl_core.so;/opt/intel/oneapi/mkl/2025.3/lib/libiomp5.so;-lm;-ldl;-lm;-ldl

It seems this `libmkl_rt.so` dispatcher is working really well.

If MKL=true, MKL is a default backend for FlexiBlas both in build and runtime:

> Configured BLAS libraries:
> System-wide (/etc/flexiblasrc):
>  MKL
>    library = /opt/intel/oneapi/mkl/2025.3/lib/intel64/libmkl_rt.so
>    comment =
> 
> System-wide from config directory (/etc/flexiblasrc.d/)
>  NETLIB
>    library = libflexiblas_netlib.so
>    comment =
>  OPENBLAS-OPENMP
>    library = libflexiblas_openblas-openmp.so
>    comment =
>  OPENBLAS-SERIAL
>    library = libflexiblas_openblas-serial.so
>    comment =
> 
> User config (/home/akurek/.flexiblasrc):
>  OPENBLAS
>    library = /opt/OpenBLAS/lib64/libopenblas.so
>    comment =
> 
> Host config (/home/akurek/.flexiblasrc.lof8):
> 
> Available hooks:
> 
> Backend and hook search paths:
>   /usr/lib64/flexiblas/
> 
> Default BLAS:
>     System:       MKL
>     User:         (none)
>     Host:         (none)
>     Active Default: MKL (System)

Related: https://github.com/tikk3r/flocs/issues/360, https://github.com/tikk3r/flocs/pull/362.