### PR TITLE
Fix MultiNest installation

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -161,7 +161,7 @@ From: fedora:42
     git clone https://github.com/JohannesBuchner/MultiNest MultiNest-src
     cd  MultiNest-src/build
     cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/MultiNest -DBLA_VENDOR=AOCL_mt ..
-    make
+    make install
     cd $INSTALLDIR
     rm -rf MultiNest-src
 

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -142,7 +142,7 @@ EOF
     else
         cmake $CMAKE_ADD_OPTION -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/MultiNest ..
     fi
-    make
+    make install
     cd $INSTALLDIR
     rm -rf MultiNest-src
 


### PR DESCRIPTION
# Description

`/opt/lofar/MultiNest/` was empty. The files were only in `/opt/lofar/MultiNest-src/{bin,lib}/` and got removed by ` rm -rf MultiNest-src`. Now they are getting installed:

> Install the project...
> -- Install configuration: ""
> -- Installing: /opt/lofar/MultiNest/lib/libmultinest.a
> -- Installing: /opt/lofar/MultiNest/lib/libmultinest.so.3.10
> -- Installing: /opt/lofar/MultiNest/lib/libmultinest.so
> [...]

and they are really in `/opt/lofar/MultiNest/` now, in both images.