### PR TITLE
Fix typo in HDF5

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -128,7 +128,7 @@ From: fedora:42
     tar xf hdf5-${HDF5_VERSION}.tar
     cd hdf5-${HDF5_VERSION}/
     # Thread safety required for WSClean's parallel gridding with facets.
-    ./configure -prefix=/opt/hdf5 --enable-build-mode=production --enable-threadsafe --enable-shared --disable-sharedlib-rpath --disable-hl --enable-cxx -enable-unsupported
+    ./configure --prefix=/opt/hdf5 --enable-build-mode=production --enable-threadsafe --enable-shared --disable-sharedlib-rpath --disable-hl --enable-cxx --enable-unsupported
     make -j $J
     #make check
     make install

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -80,7 +80,7 @@ From: fedora:42
     tar xf hdf5-${HDF5_VERSION}.tar
     cd hdf5-${HDF5_VERSION}/
     # Thread safety required for WSClean's parallel gridding with facets.
-    ./configure -prefix=/opt/hdf5 --enable-build-mode=production --enable-threadsafe --enable-shared --disable-sharedlib-rpath --disable-hl --enable-cxx -enable-unsupported
+    ./configure --prefix=/opt/hdf5 --enable-build-mode=production --enable-threadsafe --enable-shared --disable-sharedlib-rpath --disable-hl --enable-cxx --enable-unsupported
     make -j $J
     #make check
     make install


### PR DESCRIPTION
# Description

There were 2 typos after `./configure`.