### PR TITLE
Remove Python tests

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -621,7 +621,11 @@ From: fedora:42
     rm -rf /var/log/*
     uv cache clean
     dnf -y clean all
-    
+    find /opt/lofar/pyenv-py3/lib64/python${PYTHON_VERSION}/site-packages \
+        -type d \( -name "tests" -o -name "test" \) -exec rm -rf {} +
+    find /usr/lib*/python3.*/site-packages \
+        -type d \( -name "tests" -o -name "test" \) -exec rm -rf {} +
+
     #
     # init-lofar
     #

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -600,7 +600,11 @@ EOF
     rm -rf /var/log/*
     uv cache clean
     dnf -y clean all
-    
+    find /opt/lofar/pyenv-py3/lib64/python${PYTHON_VERSION}/site-packages \
+        -type d \( -name "tests" -o -name "test" \) -exec rm -rf {} +
+    find /usr/lib*/python3.*/site-packages \
+        -type d \( -name "tests" -o -name "test" \) -exec rm -rf {} +
+
     #
     # init-lofar
     #


### PR DESCRIPTION
# Description

Remove all the Python tests that should never be imported at runtime. I'm not sure about the safety of this. In the worst case this could be reverted if something ever crashes.
There are:
```
(pyenv-py3) find /opt/lofar/pyenv-py3/lib64/python3.12/site-packages \
    -type d \( -name "tests" -o -name "test" \) \
    -exec du -sh {} + | sort -hr | head -n 20
```

> 80M     /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/torch/test
> 13M     /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/pandas/tests
> 11M     /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/spherical_geometry/tests
> 8.3M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/awlofar/test
> 6.5M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/toil/test
> 5.9M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/astroquery/esa/integral/tests
> 5.7M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/pywt/tests
> 4.4M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/sunpy/data/test
> 4.2M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/scipy/stats/tests
> 3.7M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/numba/tests
> 3.1M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/schema_salad/tests
> 3.1M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/numpy/core/tests
> 2.9M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/statsmodels/genmod/tests
> 2.7M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/tables/tests
> 2.7M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/statsmodels/tsa/statespace/tests
> 2.4M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/pyarrow/tests
> 2.2M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/scipy/special/tests
> 2.1M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/scipy/spatial/tests
> 2.1M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/astroquery/mast/tests
> 1.8M    /opt/lofar/pyenv-py3/lib64/python3.12/site-packages/matplotlib/tests


```
(pyenv-py3) find /usr/lib*/python3.*/site-packages \
    -type d \( -name "tests" -o -name "test" \) \
    -exec du -sh {} + | sort -hr | head -n 20
```

> 9.9M    /usr/lib64/python3.13/site-packages/numpy/_core/tests
> 2.8M    /usr/lib64/python3.13/site-packages/numpy/lib/tests
> 1.6M    /usr/lib64/python3.13/site-packages/numpy/random/tests
> 1.4M    /usr/lib64/python3.13/site-packages/numpy/ma/tests
> 722K    /usr/lib64/python3.13/site-packages/numpy/typing/tests
> 689K    /usr/lib64/python3.13/site-packages/numpy/f2py/tests
> 516K    /usr/lib64/python3.13/site-packages/numpy/polynomial/tests
> 379K    /usr/lib64/python3.13/site-packages/numpy/linalg/tests
> 368K    /usr/lib/python3.13/site-packages/pooch/tests
> 285K    /usr/lib64/python3.13/site-packages/numpy/testing/tests
> 172K    /usr/lib64/python3.13/site-packages/numpy/tests
> 134K    /usr/lib64/python3.13/site-packages/numpy/matrixlib/tests
> 124K    /usr/lib64/python3.13/site-packages/numpy/fft/tests
> 106K    /usr/lib64/python3.13/site-packages/systemd/test
> 35K     /usr/lib64/python3.13/site-packages/hawkey/test
> 8.0K    /usr/lib64/python3.13/site-packages/numpy/_pyinstaller/tests
> 0       /usr/lib64/python3.13/site-packages/numpy/compat/tests