### PR TITLE
Fix typo in SageCal

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -341,7 +341,7 @@ From: fedora:42
         -DCMAKE_INSTALL_PREFIX=$INSTALLDIR/sagecal \
         -DLIB_ONLY=True \
         ../src
-    make -j $j
+    make -j $J
     make install
     rm -rf $INSTALLDIR/sagecal/build
     rm -rf $INSTALLDIR/sagecal/src

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -334,7 +334,7 @@ EOF
             -DLIB_ONLY=True \
             ../src
     fi
-    make -j $j
+    make -j $J
     make install
     rm -rf $INSTALLDIR/sagecal/build
     rm -rf $INSTALLDIR/sagecal/src


### PR DESCRIPTION
# Description

Variables in Bash are case-sensitive, so this is a bug.