### PR TITLE
Update package manager cache removing

### DIFF
--- a/singularity/Singularity.amd_aocl
+++ b/singularity/Singularity.amd_aocl
@@ -634,7 +634,7 @@ From: fedora:42
     # 
     rm -rf lofar_facet_selfcal
     rm -rf /var/cache/dnf/*
-    rm -rf /var/cache/yum/*
+    rm -rf /var/cache/libdnf5/*
     rm -rf /var/log/*
     uv cache clean
     dnf -y clean all

--- a/singularity/Singularity.intel_mkl
+++ b/singularity/Singularity.intel_mkl
@@ -614,7 +614,7 @@ EOF
     # 
     rm -rf lofar_facet_selfcal
     rm -rf /var/cache/dnf/*
-    rm -rf /var/cache/yum/*
+    rm -rf /var/cache/libdnf5/*
     rm -rf /var/log/*
     uv cache clean
     dnf -y clean all


### PR DESCRIPTION
# Description

Yum is no longer used in Fedora and there is no such folder. It was replaced by `/var/cache/libdnf5/`.